### PR TITLE
Readme, CMake maintenance & hostname info

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ The final output of this package -- under normal running mode -- is an "n-tuple"
 
 ## Requirements/setup
 
+This package makes use of Git submodules; after cloning, please run
+```
+git submodule update --init --recursive
+```
+to make sure that these are fetched as well.
+
+
+### Software requirements overview
 The code is primarily written in Python3, along with some C++/ROOT code (which is leveraged in Python via PyROOT).
 HEPData4ML makes use of a number of different software packages, including:
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -1,5 +1,9 @@
 # Tutorial
 
+## Prerequisites
+
+Before running the tutorials below, make sure that your environment is set up correctly (see the top-level README.md). The scripts will assume that this is set up.
+
 ## Tutorial 0
 
 In this first tutorial, we will just run Pythia8 to produce some events corresponding with the processes in Pythia's `SoftQCD` category, without any special phase space cuts. To run this, simply invoke

--- a/util/meta.py
+++ b/util/meta.py
@@ -23,16 +23,24 @@ class MetaDataHandler:
         start_time = time.time()
         self.AddElement('Metadata.Timestamp',start_time)
         self.AddElement('Metadata.Timestamp.StringUTC',time.strftime('%Y-%m-%d %H:%M:%S',time.gmtime(start_time)))
-        self.AddElement('Metadata.GitHash',self.get_git_revision_short_hash())
+        self.AddElement('Metadata.GitHash',self._get_git_revision_short_hash())
+        self.AddElement('Metadata.HostName',self._get_hostname())
         self.AddElement('Metadata.UniqueID',str(uuid.uuid4()))
         self.AddElement('Metadata.UniqueIDShort',str(uuid.uuid4())[:5]) # a second, shorter random string -- probably more convenient to use, at the risk of a higher (but still tiny) collision rate
 
-    def get_git_revision_short_hash(self): # see https://stackoverflow.com/a/21901260
+    def _get_git_revision_short_hash(self): # see https://stackoverflow.com/a/21901260
         cwd = os.path.dirname(os.path.abspath(__file__))
         try:
             result = sub.check_output(['git', 'rev-parse', '--short', 'HEAD'],cwd=cwd).decode('ascii').strip()
         except:
             result = 'NO_GIT_HASH'
+        return result
+
+    def _get_hostname(self):
+        try:
+            result = sub.check_output(['hostname']).decode('ascii').strip()
+        except:
+            result='NO_HOSTNAME'
         return result
 
     def AddMetaDataToROOTFiles(self,root_file:Union[List[str],str], cwd=None, tree_name:str='hepmc3_tree'):

--- a/util/root/display/CMakeLists.txt
+++ b/util/root/display/CMakeLists.txt
@@ -2,7 +2,7 @@
 # You should always specify a range with the newest
 # and oldest tested versions of CMake. This will ensure
 # you pick up the best policies.
-cmake_minimum_required(VERSION 3.1...3.3)
+cmake_minimum_required(VERSION 3.5...3.30)
 
 # This is your project statement. You should always list languages;
 # Listing the version is nice here since it sets lots of useful variables

--- a/util/root/jhtagger/CMakeLists.txt
+++ b/util/root/jhtagger/CMakeLists.txt
@@ -2,7 +2,7 @@
 # You should always specify a range with the newest
 # and oldest tested versions of CMake. This will ensure
 # you pick up the best policies.
-cmake_minimum_required(VERSION 3.1...3.3)
+cmake_minimum_required(VERSION 3.5...3.30)
 
 # This is your project statement. You should always list languages;
 # Listing the version is nice here since it sets lots of useful variables


### PR DESCRIPTION
This PR adds just a few small but important things:
- Some slight modifications to the README, to hopefully make it clearer that one needs to initialize the git submodules to get things working; and that running the tutorials will first require doing the environment setup.
- Updating the minimum CMake versions for the `jhtagger` and `display` sub-packages. This is almost meaningless in practice but having the minimum versions set too low will actually throw errors with CMake 4.X, as some stuff from <3.5 is now deprecated. Given the offerings on CVMFS and how old CMake <3.5 is, I don't think one needs to worry about this much.
- Adding `hostname` to the metadata. This is probably not super-necessary, but given the pretty extensive metadata already, it's also nice to know *where* a dataset was made. Maybe this can help with debugging?