### PR TITLE
hotfix for condor usage

### DIFF
--- a/util/condor/condor_job.sh
+++ b/util/condor/condor_job.sh
@@ -80,7 +80,6 @@ python ${gitdir}/run.py \
   -o ${output_filename} \
   -rng ${rng_seed} \
   -pb 1 \
-  --delete_stats 0 \
   --split 0 \
   -del_delphes $delete_delphes \
   -pc ${pythia_config} \


### PR DESCRIPTION
This is a small but important PR -- it fixes an issue that cropped up with HTCondor usage, where jobs were trying to set a command line argument that has been deprecated.