### PR TITLE
Making HepMC3 into a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = external/delphes
 	url = git@github.com:janTOffermann/delphes.git
         ignore = untracked
+[submodule "external/hepmc/HepMC3"]
+	path = external/hepmc/HepMC3
+	url = ssh://git@gitlab.cern.ch:7999/hepmc/HepMC3.git

--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ For usage on CVMFS systems, the setup script in `setup/cvmfs/` is recommended in
 source setup/cvmfs/setup.sh
 ```
 
-### Notes on dependencies: automatically installed packages
-The Delphes, HepMC3 and fastjet dependencies will automatically be installed locally (i.e. within this repository) by the package during runtime, if they are not found (or their installation paths set to `None` in the config file), in `external/`.Should you wish to intead use existing installations of these packages, their locations should be provided in the aforementioned config file. A few notes:
-- At the present moment, the HepMC3 path *should* be set to `None`, as we leverage features not yet available in an official HepMC3 release (but which are in its `master` branch on CERN GitLab). This may eventually be changed to use an official HepMC3 release.
-- Similarly, the Delphes path should be set to `None`; Delphes is now a git submodule of this package, as we use a custom fork -- this allows use of some (provided) custom Delphes cards, plus it importantly adds the ability to set the random number generator seed for Delphes at the command line.
+### Notes on dependencies: automatically installed packages and git submodules
+The Delphes, HepMC3 and fastjet dependencies will automatically be installed in `external/` (i.e. within this repository) by the package during runtime, if they are not found (or their installation paths set to `None` in the config file), with the former two being `git submodules` of this package.
+Should you wish to intead use existing installations of these packages, their locations should be provided in the aforementioned config file. A few notes:
+- The code leverages features in HepMC3 and Delphes that may not presently be available in official releases (or in the case of Delphes, in the official repository: the submodule corresponds to my own fork of the project).
+    - The "non-standard" HepMC3 features are presently part of the master branch of the [official HepMC3 repository](https://gitlab.cern.ch/hepmc/HepMC3/-/tree/master?ref_type=heads), so it is foreseeable that an official release may eventually be used instead.
+    - By contrast, the Delphes-based code makes use of some special features that are only available in my fork of the project; this is true both of some of the provided Delphes detector cards, as well as the `DelphesHepMC3ROOT` executable in `external/delphes_custom` (as well as the `DelphesWrapper` Python interface).
 
-Note that the Pythia8 and fastjet installations that are used *must* have the Python interface built -- running the script will check the fastjet Python interface, and if it's not present it will install in `external/`.
+Note that the Pythia8 and fastjet installations that are used *must* have the Python interface built -- running the script will check the fastjet Python interface, and if it's not present it will install in `external/fastjet`.
 
 ## Configuring and running the data generation
 

--- a/config/config.py
+++ b/config/config.py
@@ -12,7 +12,6 @@ config = {
         'fsr' : True, # Pythia8 final-state radiation flag
         'rng' : 1, # Pythia8 RNG seed
         'verbose' : False,
-        'hepmc_dir': None, # Directory containing the HepMC3 installation. If None, will build in a local directory "external/hepmc". Note that we currently use a custom fork of HepMC3, so you probably want to leave this as None.
         'hepmc_format': 'root' # Options are 'root' and 'ascii'. The ROOT option provides superior filesize and random-access capability (useful if making samples for pileup overlay), at the cost of being less human-readable.
     },
 

--- a/external/.gitignore
+++ b/external/.gitignore
@@ -1,2 +1,1 @@
 fastjet
-hepmc

--- a/tutorial/config/config_0.py
+++ b/tutorial/config/config_0.py
@@ -12,7 +12,6 @@ config = {
         'fsr' : True, # Pythia8 final-state radiation flag
         'rng' : 1, # Pythia8 RNG seed
         'verbose' : False,
-        'hepmc_dir': None, # Directory containing the HepMC3 installation. If None, will build in a local directory "external/hepmc". Note that we currently use a custom fork of HepMC3, so you probably want to leave this as None.
         'hepmc_format': 'root' # Options are 'root' and 'ascii'. The ROOT option provides superior filesize and random-access capability (useful if making samples for pileup overlay), at the cost of being less human-readable.
     },
 

--- a/tutorial/config/config_1.py
+++ b/tutorial/config/config_1.py
@@ -12,7 +12,6 @@ config = {
         'fsr' : True, # Pythia8 final-state radiation flag
         'rng' : 1, # Pythia8 RNG seed
         'verbose' : False,
-        'hepmc_dir': None, # Directory containing the HepMC3 installation. If None, will build in a local directory "external/hepmc". Note that we currently use a custom fork of HepMC3, so you probably want to leave this as None.
         'hepmc_format': 'root' # Options are 'root' and 'ascii'. The ROOT option provides superior filesize and random-access capability (useful if making samples for pileup overlay), at the cost of being less human-readable.
     },
 

--- a/tutorial/config/config_2.py
+++ b/tutorial/config/config_2.py
@@ -12,7 +12,6 @@ config = {
         'fsr' : True, # Pythia8 final-state radiation flag
         'rng' : 1, # Pythia8 RNG seed
         'verbose' : False,
-        'hepmc_dir': None, # Directory containing the HepMC3 installation. If None, will build in a local directory "external/hepmc". Note that we currently use a custom fork of HepMC3, so you probably want to leave this as None.
         'hepmc_format': 'root' # Options are 'root' and 'ascii'. The ROOT option provides superior filesize and random-access capability (useful if making samples for pileup overlay), at the cost of being less human-readable.
     },
 

--- a/util/config.py
+++ b/util/config.py
@@ -106,7 +106,10 @@ class Configurator:
         return self.config['generation']['hepmc_format']
 
     def GetHepMC3Directory(self)->str:
-        return self.config['generation']['hepmc_dir']
+        try:
+            return self.config['generation']['hepmc_dir']
+        except:
+            return None # this will be interpreted by our tools to point to external/hepmc (our HepMC3 git submodule) -- could consider just setting that here
 
     def SetHepMC3Directory(self,dir:str):
         self.config['generation']['hepmc_dir'] = dir

--- a/util/delphes/setup.py
+++ b/util/delphes/setup.py
@@ -12,8 +12,6 @@ class DelphesSetup:
     """
     def __init__(self,delphes_dir:Optional[str]=None):
         self.SetDirectory(delphes_dir)
-        self.delphes_download = 'https://github.com/delphes/delphes/archive/refs/tags/3.5.1pre12.tar.gz' # LCG_105 - LCG_107 has 3.5.1pre09
-        self.delphes_file = 'delphes-{}'.format(self.delphes_download.split('/')[-1]) # TODO: A bit hacky
         self.executable = None
         self.prefix = self.__class__.__name__
         self.expected_stdout = 281
@@ -71,7 +69,6 @@ class DelphesSetup:
         command = ['cmake','./']
         self.run_command_with_progress(command,cwd=self.build_dir, prefix='Configuring Delphes:',output_length=18)
 
-        # self.build_dir = '{}/{}'.format(self.delphes_dir,self.delphes_file.replace('.tar.gz','')) # TODO: clean this up
         self._print('Building Delphes @ {} .'.format(self.build_dir))
         command = ['cmake', '--build','.', '-j{}'.format(j)]
         self.run_command_with_progress(command,cwd=self.build_dir, prefix='Building Delphes:')#,output_length=self.expected_stdout)

--- a/util/hepmc/setup.py
+++ b/util/hepmc/setup.py
@@ -1,4 +1,3 @@
-from util.qol_utils.misc import stdout_redirected
 from util.qol_utils.progress_bar import printProgressBar, printProgressWithOutput
 import subprocess as sub
 import sys, os, glob, re, pathlib, importlib, threading, queue, uuid

--- a/util/hepmc/setup.py
+++ b/util/hepmc/setup.py
@@ -1,7 +1,7 @@
 from util.qol_utils.misc import stdout_redirected
 from util.qol_utils.progress_bar import printProgressBar, printProgressWithOutput
 import subprocess as sub
-import sys, os, glob, re, pathlib, importlib, threading, atexit, queue, uuid
+import sys, os, glob, re, pathlib, importlib, threading, queue, uuid
 from collections import deque
 from typing import Optional, Union
 
@@ -928,6 +928,3 @@ class HepMCSetup:
             require_read_with_index=require_read_with_index,
             force=True
         )
-
-# Optional: Clean up on exit
-atexit.register(lambda: print("HepMCSetup: Cleanup complete") if _setup_completed else None)

--- a/util/hepmc/setup.py
+++ b/util/hepmc/setup.py
@@ -85,7 +85,6 @@ class _HepMCSetupInternal:
     """
 
     def __init__(self, hepmc_dir=None, verbose: bool = False):
-        self.version = '3.3.1'  # what version we'll try to install, if necessary
         self.hepmc_dir_default = os.path.dirname(os.path.abspath(__file__)) + '/../../external/hepmc'
         self.python_dir = None
         self.SetVerbose(verbose)
@@ -106,12 +105,11 @@ class _HepMCSetupInternal:
         self.logfile = '{}/log.stdout'.format(self.hepmc_dir)
         self.errfile = '{}/log.stderr'.format(self.hepmc_dir)
 
-        self.source_dir = '{}/HepMC3-{}'.format(self.hepmc_dir, self.version)
+        # self.source_dir = '{}/HepMC3-{}'.format(self.hepmc_dir, self.version)
+        self.source_dir = '{}/HepMC3'.format(self.hepmc_dir)
         self.build_dir = '{}/hepmc3-build'.format(self.hepmc_dir)
         self.install_dir = '{}/hepmc3-install'.format(self.hepmc_dir)
 
-        if self.verbose:
-            print('CALLING SetPythonDirectory() within SetDirectory().\tself.install_dir = {}'.format(self.install_dir))
         self.SetPythonDirectory()
 
     def GetDirectory(self) -> str:
@@ -133,99 +131,6 @@ class _HepMCSetupInternal:
         Adding this to the $PYTHONPATH (sys.path) will allow one to import it.
         """
         return self.python_dir
-
-    def Download(self):
-        """
-        Instead of downloading the official HepMC3 release, this will pull
-        a specific commit from the master branch on CERN GitLab.
-        This incorporates some features I have added, that may not have yet
-        propagated to an official release.
-        """
-        if pathlib.Path(self.source_dir).exists():
-            self._vprint('Found existing HepMC3 source directory: {}'.format(self.source_dir))
-            self._vprint('... Skipping download.')
-            return  # if source exists, don't download again
-
-        with open(self.logfile, 'a') as f, open(self.errfile, 'a') as g:
-            # add an empty space -- nice to separate outputs from different commands
-            f.write('\n')
-            g.write('\n')
-
-            # Fetch the HepMC3 source
-            commit_sha = '136fd57d52ce8d79c224870469414bcf7f81b995'
-            hepmc_download = 'https://gitlab.cern.ch/hepmc/HepMC3/-/archive/{sha}/HepMC3-{sha}.tar.gz'.format(sha=commit_sha)
-            hepmc_file = hepmc_download.split('/')[-1]
-            self._vprint('Downloading HepMC3 from {}.'.format(hepmc_download))
-
-            # Depending on Linux/macOS, we use wget or curl.
-            has_wget = True
-            with stdout_redirected():
-                try:
-                    sub.check_call('which wget'.split(' '))
-                except:
-                    has_wget = False
-                    pass
-
-            if has_wget:
-                sub.check_call(['wget', hepmc_download], cwd=self.hepmc_dir, stdout=f, stderr=g)
-            else:
-                sub.check_call(['curl', hepmc_download, '-o', hepmc_file], cwd=self.hepmc_dir, stdout=f, stderr=g)
-            sub.check_call(['tar', 'xzf', hepmc_file], cwd=self.hepmc_dir, stdout=f, stderr=g)
-            sub.check_call(['rm', hepmc_file], cwd=self.hepmc_dir, stdout=f, stderr=g)
-
-            # Rename the source dir to match the one of the official release.
-            # A little hacky but it will work for now.
-            source_dir = '/'.join(self.source_dir.split('/')[:-1]) + '/' + hepmc_file.split('.')[0]
-            try:
-                sub.check_call(['mv', source_dir, self.source_dir])
-            except:  # assume it already exists -- edge case
-                sub.check_call(['rm', '-r', source_dir])
-                pass
-
-    def DownloadFork(self):
-        """
-        Instead of downloading the official HepMC3 release, this will pull
-        a (public) fork of the project from CERN GitLab.
-        """
-        if pathlib.Path(self.source_dir).exists():
-            self._vprint('Found existing HepMC3 source directory: {}'.format(self.source_dir))
-            self._vprint('... Skipping download.')
-            return  # if source exists, don't download again
-
-        with open(self.logfile, 'a') as f, open(self.errfile, 'a') as g:
-            # add an empty space -- nice to separate outputs from different commands
-            f.write('\n')
-            g.write('\n')
-
-            # Fetch the HepMC3 source
-            hepmc_download = 'https://gitlab.cern.ch/jaofferm/HepMC3/-/archive/jaofferm_devel/HepMC3-jaofferm_devel.tar.gz'
-            hepmc_file = hepmc_download.split('/')[-1]
-            self._vprint('Downloading HepMC3 from {}.'.format(hepmc_download))
-
-            # Depending on Linux/macOS, we use wget or curl.
-            has_wget = True
-            with stdout_redirected():
-                try:
-                    sub.check_call('which wget'.split(' '))
-                except:
-                    has_wget = False
-                    pass
-
-            if has_wget:
-                sub.check_call(['wget', hepmc_download], cwd=self.hepmc_dir, stdout=f, stderr=g)
-            else:
-                sub.check_call(['curl', hepmc_download, '-o', hepmc_file], cwd=self.hepmc_dir, stdout=f, stderr=g)
-            sub.check_call(['tar', 'xzf', hepmc_file], cwd=self.hepmc_dir, stdout=f, stderr=g)
-            sub.check_call(['rm', hepmc_file], cwd=self.hepmc_dir, stdout=f, stderr=g)
-
-            # Rename the source dir to match the one of the official release.
-            # A little hacky but it will work for now.
-            source_dir = '/'.join(self.source_dir.split('/')[:-1]) + '/' + hepmc_file.split('.')[0]
-            try:
-                sub.check_call(['mv', source_dir, self.source_dir])
-            except:  # assume it already exists -- edge case
-                sub.check_call(['rm', '-r', source_dir])
-                pass
 
     def Make(self, j: int = 4):
         with open(self.logfile, 'a') as f, open(self.errfile, 'a') as g:
@@ -317,7 +222,6 @@ class _HepMCSetupInternal:
             return
 
         self.SetDirectory()
-        self.Download()
         self.Make(j)
         self.SetPythonDirectory()
 


### PR DESCRIPTION
This PR turns HepMC3 into a `git submodule`, which is likely preferable to the rather home-brewed method of handling these dependencies that I've been using. (For the time being, I am keeping from turning fastjet into a submodule as well, only because the code doesn't require any features outside of its official release -- I may ultimately change it anyway to simplify dependency handling).